### PR TITLE
Add the yaml syntax error trace

### DIFF
--- a/bin/cloudnet/tosca/importers.py
+++ b/bin/cloudnet/tosca/importers.py
@@ -178,8 +178,16 @@ class FilesystemImporter(Importer):
         '''
             Loads a YAML file.
         '''
+        template = ""
         with open(filename, 'r') as stream:
-            return yaml.load(stream, Loader=yaml.FullLoader)
+            try:
+                template = yaml.load(stream, Loader=yaml.SafeLoader)
+            except yaml.YAMLError as exc:
+                if hasattr(exc, 'problem_mark'):
+                    mark = exc.problem_mark
+                    raise ValueError("Yaml error line %s column %s" % (mark.line+1, mark.column+1))
+
+        return template
 
 class UrlImporter(Importer):
     '''

--- a/bin/cloudnet/tosca/importers.py
+++ b/bin/cloudnet/tosca/importers.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# Software Name : Cloudnet TOSCA toolbox 
+# Software Name : Cloudnet TOSCA toolbox
 # Version: 1.0
 # SPDX-FileCopyrightText: Copyright (c) 2020 Orange
 # SPDX-License-Identifier: Apache-2.0
@@ -13,17 +13,20 @@
 # Software description: TOSCA to Cloudnet Translator
 ######################################################################
 
-import requests # for HTTP GET requests.
-import yaml # for parsing YAML.
-import zipfile # for reading ZIP files.
+import requests  # for HTTP GET requests.
+import yaml      # for parsing YAML.
+import zipfile   # for reading ZIP files.
+import os
+import logging   # for logging purposes.
 
 import cloudnet.tosca.configuration as configuration
+
 configuration.DEFAULT_CONFIGURATION['logging']['loggers'][__name__] = {
     'level': 'INFO',
 }
 
-import logging # for logging purposes.
 LOGGER = logging.getLogger(__name__)
+
 
 class ToscaServiceTemplate(object):
     '''
@@ -59,6 +62,7 @@ class ToscaServiceTemplate(object):
         '''
         return self.importer.imports(path)
 
+
 class Importer(object):
     '''
         Abstract base class for importers of TOSCA service templates.
@@ -78,7 +82,7 @@ class Importer(object):
         # Init the cache of children importers.
         self.children_importers = {}
         # Store the first created imported as the root importer.
-        if Importer.root_importer == None:
+        if Importer.root_importer is None:
             Importer.root_importer = self
         LOGGER.debug(str(self) + ' created')
 
@@ -115,32 +119,34 @@ class Importer(object):
         elif base_path.startswith('file:'):
             base_path = base_path[len('file:'):]
             importer = Importer.root_importer.children_importers.get(base_path)
-            if importer == None:
+            if importer is None:
                 importer = FilesystemImporter(base_path)
                 Importer.root_importer.children_importers[base_path] = importer
         elif base_path.startswith('http:') or base_path.startswith('https:'):
             importer = Importer.root_importer.children_importers.get(base_path)
-            if importer == None:
+            if importer is None:
                 importer = UrlImporter(base_path)
                 Importer.root_importer.children_importers[base_path] = importer
         # else reuse or create an importer of the same type of the current importer.
         else:
             importer = self.children_importers.get(base_path)
-            if importer == None:
+            if importer is None:
                 importer = self.new_importer(base_path)
                 self.children_importers[base_path] = importer
 
         # Is this tosca service template already loaded?
         tosca_service_template = importer.already_loaded_tosca_service_templates.get(filename)
         if tosca_service_template:
-            return tosca_service_template # then return it.
+            return tosca_service_template  # then return it.
 
         # Load the YAML content.
         LOGGER.debug('Loads ' + importer.base_path + filename + ' from ' + str(importer))
         try:
             yaml_content = importer.load_yaml(importer.base_path + filename)
-        except FileNotFoundError:
-            raise FileNotFoundError('No such file: ' +  filename)
+        except yaml.YAMLError as exc:
+            if hasattr(exc, 'problem_mark'):
+                mark = exc.problem_mark
+                raise ValueError("(1) Yaml error line %s column %s" % (mark.line+1, mark.column+1))
 
         # Create the TOSCA service template.
         tosca_service_template = ToscaServiceTemplate(filename, yaml_content, importer)
@@ -163,6 +169,7 @@ class Importer(object):
         '''
         pass
 
+
 class FilesystemImporter(Importer):
     '''
         Importer of TOSCA service templates as files.
@@ -178,6 +185,9 @@ class FilesystemImporter(Importer):
         '''
             Loads a YAML file.
         '''
+
+        # load yaml descriptor and raise an error with line and column
+        # if this appens
         template = ""
         with open(filename, 'r') as stream:
             try:
@@ -188,6 +198,7 @@ class FilesystemImporter(Importer):
                     raise ValueError("Yaml error line %s column %s" % (mark.line+1, mark.column+1))
 
         return template
+
 
 class UrlImporter(Importer):
     '''
@@ -208,6 +219,7 @@ class UrlImporter(Importer):
         if response.status_code == 404:
             raise FileNotFoundError(filename)
         return yaml.load(response.text, Loader=yaml.FullLoader)
+
 
 class ArchiveImporter(Importer):
     '''
@@ -249,6 +261,7 @@ class ArchiveImporter(Importer):
         except KeyError:
             raise FileNotFoundError(filename)
 
+
 def imports(tosca_service_template_path, alias={}):
     # Inits the root loader of TOSCA service templates.
     importer = FilesystemImporter('', alias)
@@ -261,6 +274,6 @@ def imports(tosca_service_template_path, alias={}):
         if type(tosca_meta) != dict:
             raise ValueError('Invalid TOSCA-Metadata/TOSCA.meta file')
         entry_definitions = tosca_meta.get('Entry-Definitions')
-        if entry_definitions == None:
+        if entry_definitions is None:
             raise ValueError('No entry-definitions in TOSCA-Metadata/TOSCA.meta')
         return importer.imports(entry_definitions)

--- a/bin/cloudnet/tosca/importers.py
+++ b/bin/cloudnet/tosca/importers.py
@@ -16,7 +16,6 @@
 import requests  # for HTTP GET requests.
 import yaml      # for parsing YAML.
 import zipfile   # for reading ZIP files.
-import os
 import logging   # for logging purposes.
 
 import cloudnet.tosca.configuration as configuration

--- a/bin/cloudnet/tosca/type_system.py
+++ b/bin/cloudnet/tosca/type_system.py
@@ -221,6 +221,10 @@ class TypeChecker(Checker):
                     import_namespace_prefix = import_namespace_prefix + ':'
                 self.load_tosca_yaml_template(import_filepath, tosca_service_template, import_namespace_prefix, already_loaded_paths)
             except FileNotFoundError:
+                # It seems that we get a program crash here but I didn't figure out 
+                # how to deal with yet !
+                # This case occurs when a file imported is not present
+                # JLC 20201126
                 self.error(':imports[' + str(index) + ']:file: ' + import_filepath + ' not found')
             index = index + 1
 

--- a/examples/OASIS_TOSCA_1.2/run.sh
+++ b/examples/OASIS_TOSCA_1.2/run.sh
@@ -42,6 +42,10 @@ Help()
 ################################################################################
 TOSCA_SyntaxCheck()
 {
+   # Configure0 a log file
+   _LOG=$(basename "${PWD}")-$(date +%F_%H-%M-%S).log
+   mkdir -p logs 2>/dev/null
+
    # All description files translation
    echo -e "\n${normal}${magenta}*** Descriptor files syntax checking ***${reset}" | tee -a logs/${_LOG}
    
@@ -268,10 +272,6 @@ done
 
 # Load cloundnet commands.
 . $CLOUDNET_BINDIR/cloudnet_rc.sh
-
-# Configure0 a log file
-_LOG=$(basename "${PWD}")-$(date +%F_%H-%M-%S).log
-mkdir -p logs 2>/dev/null
 
 # Variable used to know if the Syntax checking has bee done
 SYNTAX_CHECK=False

--- a/examples/OpenStack/run.sh
+++ b/examples/OpenStack/run.sh
@@ -42,6 +42,10 @@ Help()
 ################################################################################
 TOSCA_SyntaxCheck()
 {
+   # Configure0 a log file
+   _LOG=$(basename "${PWD}")-$(date +%F_%H-%M-%S).log
+   mkdir -p logs 2>/dev/null
+
    # All description files translation
    echo -e "\n${normal}${magenta}*** Descriptor files syntax checking ***${reset}" | tee -a logs/${_LOG}
    
@@ -268,10 +272,6 @@ done
 
 # Load cloundnet commands.
 . $CLOUDNET_BINDIR/cloudnet_rc.sh
-
-# Configure0 a log file
-_LOG=$(basename "${PWD}")-$(date +%F_%H-%M-%S).log
-mkdir -p logs 2>/dev/null
 
 # Variable used to know if the Syntax checking has bee done
 SYNTAX_CHECK=False


### PR DESCRIPTION
I have added the check of the yaml.load error check to give the line number and the column to the user.
Usefull when a big file is check and a minor error can generate many subsequent errors.
Give a look and fill free to modify the way I did it.