### PR TITLE
allow several layered config files 

### DIFF
--- a/bin/cloudnet/tosca/configuration.py
+++ b/bin/cloudnet/tosca/configuration.py
@@ -25,19 +25,13 @@ LOGGER = logging.getLogger(__name__)
 CONFIGURATION_FILE = "tosca2cloudnet.yaml"
 
 
-def load(config_file=CONFIGURATION_FILE, ignored_keys=[]):
+def load(config_file=CONFIGURATION_FILE):
     configuration = DEFAULT_CONFIGURATION
 
     if os.path.exists(config_file):
         # Load the configuration file if it exists.
         with open(config_file, "r") as stream:
             content = yaml.load(stream, Loader=yaml.FullLoader)
-            # delete all subkeys of content which are in ignored values
-            for d in content.values():
-                if isinstance(d, dict):
-                    for k in ignored_keys:
-                        if k in d:
-                            del d[k]
             configuration = merge_dict(DEFAULT_CONFIGURATION, content)
 
     # Configure logging.

--- a/bin/cloudnet/tosca/configuration.py
+++ b/bin/cloudnet/tosca/configuration.py
@@ -25,21 +25,20 @@ LOGGER = logging.getLogger(__name__)
 CONFIGURATION_FILE = "tosca2cloudnet.yaml"
 
 
-def load(config_file=CONFIGURATION_FILE):
+def load(config_files=[CONFIGURATION_FILE]):
     configuration = DEFAULT_CONFIGURATION
-
-    if os.path.exists(config_file):
-        # Load the configuration file if it exists.
-        with open(config_file, "r") as stream:
-            content = yaml.load(stream, Loader=yaml.FullLoader)
-            configuration = merge_dict(DEFAULT_CONFIGURATION, content)
 
     # Configure logging.
     logging.config.dictConfig(configuration["logging"])
 
-    # Log the configuration file loading.
-    if configuration != DEFAULT_CONFIGURATION:
-        LOGGER.info(config_file + " loaded.")
+    for config_file in config_files:
+        # Load the configuration file if it exists.
+        if os.path.exists(config_file):
+            # Log the configuration file loading.
+            LOGGER.info(config_file + " loaded.")
+            with open(config_file, "r") as stream:
+                content = yaml.load(stream, Loader=yaml.FullLoader)
+                configuration = merge_dict(configuration, content)
 
     # Return the configuration.
     return Configuration(configuration)

--- a/bin/cloudnet/tosca/tosca2cloudnet.py
+++ b/bin/cloudnet/tosca/tosca2cloudnet.py
@@ -79,11 +79,13 @@ def main(argv):
             default="",
             help="json log output processing file.",
         )
+
         parser.add_argument(
             "--config-file",
             metavar="<config_file.yaml>",
-            default=configuration.CONFIGURATION_FILE,
-            help="use provided YAML file as default configuration",
+            default=[configuration.CONFIGURATION_FILE],
+            help="use provided YAML file(s) as default configuration",
+            nargs="+",
         )
         (args, extra_args) = parser.parse_known_args(argv)
 
@@ -92,9 +94,7 @@ def main(argv):
         )
 
         # Load configuration.
-        config = configuration.load(
-            config_file=args.config_file,
-        )
+        config = configuration.load(args.config_file)
 
         # Load the TOSCA service template.
         try:

--- a/bin/cloudnet/tosca/tosca2cloudnet.py
+++ b/bin/cloudnet/tosca/tosca2cloudnet.py
@@ -80,12 +80,6 @@ def main(argv):
             help="json log output processing file.",
         )
         parser.add_argument(
-            "--ignore-target-config",
-            dest="ignore_target_config",
-            action="store_true",
-            help="ignore target directory configuration, force it to default values.",
-        )
-        parser.add_argument(
             "--config-file",
             metavar="<config_file.yaml>",
             default=configuration.CONFIGURATION_FILE,
@@ -100,9 +94,6 @@ def main(argv):
         # Load configuration.
         config = configuration.load(
             config_file=args.config_file,
-            ignored_keys=[processors.Generator.TARGET_DIRECTORY]
-            if args.ignore_target_config
-            else [],
         )
 
         # Load the TOSCA service template.


### PR DESCRIPTION
To fix issue 258 in ToscaToolbox web frontend or give a base config + additional layers, let the user use several config files in the command line : 

```
tosca2cloudnet --config-file A.yaml B.yaml --otheroptions ...
```
if A.yaml sets value1 and value2 to 'A' and B.yaml sets value2 and value3 to 'B', then the final config will be value1=A, value2=B value3 = B

This is compatible with preceding way of giving only one config file but allows several configs for several sub-items.


